### PR TITLE
Expose AlignedView::new

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,7 @@ pub struct AlignedView<T> {
 }
 
 impl<T: View> AlignedView<T> {
-    fn new(view: T, alignment: Align) -> Self {
+    pub fn new(view: T, alignment: Align) -> Self {
         Self {
             view,
             alignment,


### PR DESCRIPTION
Easier to programmatically set alignment rather than matching and calling
the methods.