### PR TITLE
Update to cursive_core 0.3.0-alpha.0, cursive 0.17.0-alpha.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ documentation = "https://docs.rs/cursive-aligned-view"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cursive_core = "0.2"
+cursive_core = "0.3.0-alpha.0"
 
 [dev-dependencies]
 serde_json = "1.0"
-cursive = "0.16"
+cursive = "0.17.0-alpha.0"
 crossbeam = "0.8"
 insta = "1.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@
 use cursive_core::align::{Align, HAlign, VAlign};
 use cursive_core::direction::Direction;
 use cursive_core::event::{AnyCb, Event, EventResult};
-use cursive_core::view::{Selector, View, ViewNotFound};
+use cursive_core::view::{CannotFocus, Selector, View, ViewNotFound};
 use cursive_core::{Printer, Rect, Vec2};
 
 /// Use this trait to extend all `cursive::view::View` instances to support
@@ -365,11 +365,11 @@ impl<T: View> View for AlignedView<T> {
         self.view.call_on_any(sel, cb);
     }
 
-    fn focus_view(&mut self, sel: &Selector) -> Result<(), ViewNotFound> {
+    fn focus_view(&mut self, sel: &Selector) -> Result<EventResult, ViewNotFound> {
         self.view.focus_view(sel)
     }
 
-    fn take_focus(&mut self, source: Direction) -> bool {
+    fn take_focus(&mut self, source: Direction) -> Result<EventResult, CannotFocus> {
         self.view.take_focus(source)
     }
 

--- a/tests/end2end.rs
+++ b/tests/end2end.rs
@@ -27,7 +27,7 @@ where
 #[test]
 fn squeeze_underfill_top_left() {
     let (frames, _) = setup_test_environment(|siv| {
-        let panel = Panel::new(TextView::new("A very long text that will reach the limit of some screens")).title("Hello, world!");
+        let panel = Panel::new(TextView::new("A very long text that will reach the limit of some screens"));
         let aligned = AlignedView::with_top_left(panel).resized(SizeConstraint::Fixed(15), SizeConstraint::Fixed(3));
         siv.add_fullscreen_layer(aligned);
     });
@@ -37,7 +37,7 @@ fn squeeze_underfill_top_left() {
 #[test]
 fn squeeze_underfill_top_center() {
     let (frames, _) = setup_test_environment(|siv| {
-        let panel = Panel::new(TextView::new("A very long text that will reach the limit of some screens")).title("Hello, world!");
+        let panel = Panel::new(TextView::new("A very long text that will reach the limit of some screens"));
         let aligned = AlignedView::with_top_center(panel).resized(SizeConstraint::Fixed(15), SizeConstraint::Fixed(3));
         siv.add_fullscreen_layer(aligned);
     });
@@ -47,7 +47,7 @@ fn squeeze_underfill_top_center() {
 #[test]
 fn squeeze_underfill_top_right() {
     let (frames, _) = setup_test_environment(|siv| {
-        let panel = Panel::new(TextView::new("A very long text that will reach the limit of some screens")).title("Hello, world!");
+        let panel = Panel::new(TextView::new("A very long text that will reach the limit of some screens"));
         let aligned = AlignedView::with_top_right(panel).resized(SizeConstraint::Fixed(15), SizeConstraint::Fixed(3));
         siv.add_fullscreen_layer(aligned);
     });
@@ -57,7 +57,7 @@ fn squeeze_underfill_top_right() {
 #[test]
 fn squeeze_underfill_center_left() {
     let (frames, _) = setup_test_environment(|siv| {
-        let panel = Panel::new(TextView::new("A very long text that will reach the limit of some screens")).title("Hello, world!");
+        let panel = Panel::new(TextView::new("A very long text that will reach the limit of some screens"));
         let aligned = AlignedView::with_center_left(panel).resized(SizeConstraint::Fixed(15), SizeConstraint::Fixed(3));
         siv.add_fullscreen_layer(aligned);
     });
@@ -67,7 +67,7 @@ fn squeeze_underfill_center_left() {
 #[test]
 fn squeeze_underfill_center() {
     let (frames, _) = setup_test_environment(|siv| {
-        let panel = Panel::new(TextView::new("A very long text that will reach the limit of some screens")).title("Hello, world!");
+        let panel = Panel::new(TextView::new("A very long text that will reach the limit of some screens"));
         let aligned = AlignedView::with_center(panel).resized(SizeConstraint::Fixed(15), SizeConstraint::Fixed(3));
         siv.add_fullscreen_layer(aligned);
     });
@@ -77,7 +77,7 @@ fn squeeze_underfill_center() {
 #[test]
 fn squeeze_underfill_center_right() {
     let (frames, _) = setup_test_environment(|siv| {
-        let panel = Panel::new(TextView::new("A very long text that will reach the limit of some screens")).title("Hello, world!");
+        let panel = Panel::new(TextView::new("A very long text that will reach the limit of some screens"));
         let aligned = AlignedView::with_center_right(panel).resized(SizeConstraint::Fixed(15), SizeConstraint::Fixed(3));
         siv.add_fullscreen_layer(aligned);
     });
@@ -87,7 +87,7 @@ fn squeeze_underfill_center_right() {
 #[test]
 fn squeeze_underfill_bottom_left() {
     let (frames, _) = setup_test_environment(|siv| {
-        let panel = Panel::new(TextView::new("A very long text that will reach the limit of some screens")).title("Hello, world!");
+        let panel = Panel::new(TextView::new("A very long text that will reach the limit of some screens"));
         let aligned = AlignedView::with_bottom_left(panel).resized(SizeConstraint::Fixed(15), SizeConstraint::Fixed(3));
         siv.add_fullscreen_layer(aligned);
     });
@@ -97,7 +97,7 @@ fn squeeze_underfill_bottom_left() {
 #[test]
 fn squeeze_underfill_bottom_center() {
     let (frames, _) = setup_test_environment(|siv| {
-        let panel = Panel::new(TextView::new("A very long text that will reach the limit of some screens")).title("Hello, world!");
+        let panel = Panel::new(TextView::new("A very long text that will reach the limit of some screens"));
         let aligned = AlignedView::with_bottom_center(panel).resized(SizeConstraint::Fixed(15), SizeConstraint::Fixed(3));
         siv.add_fullscreen_layer(aligned);
     });
@@ -107,7 +107,7 @@ fn squeeze_underfill_bottom_center() {
 #[test]
 fn squeeze_underfill_bottom_right() {
     let (frames, _) = setup_test_environment(|siv| {
-        let panel = Panel::new(TextView::new("A very long text that will reach the limit of some screens")).title("Hello, world!");
+        let panel = Panel::new(TextView::new("A very long text that will reach the limit of some screens"));
         let aligned = AlignedView::with_bottom_right(panel).resized(SizeConstraint::Fixed(15), SizeConstraint::Fixed(3));
         siv.add_fullscreen_layer(aligned);
     });


### PR DESCRIPTION
This updates to the latest prerelease versions of Cursive. There were some compiler errors that I resolved.

I updated some of the underfill tests to not have a title for the panel. Previously, the title did not render at all for these test cases. The new behavior is to render the title and cut it off to fit in the allotted space. Strangely, the closing `|` is not present. I assumed this was an upstream bug with the combination of `ResizableView` and `TextView`, so I just removed the titles.

This is roughly what the new output would have looked like, if I hadn't updated the test cases:

```
+-| Hello Wo+
| Some long |
+-----------+
```
